### PR TITLE
Reduce dependencies of memtree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ categories = ["data-structures", "algorithms", "no-std"]
 serde = ["dep:serde"]
 
 [dependencies]
-num = { version = "0.4", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -3,7 +3,7 @@ use core::{
     fmt::{Debug, Display},
     ops::{Range, RangeInclusive},
 };
-use num::{CheckedAdd, One};
+use num_traits::{CheckedAdd, One};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
The full `num` crate is not needed (only the num_trait)